### PR TITLE
Compile sass only if changed, and build if files changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+package/tool/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ ___
 
 `LibSassBuilder` can be installed on any project, however the underlying build tool requires [.NET 5](https://dotnet.microsoft.com/download/dotnet/5.0) installed on the machine.
 
+## Project options
+
+The project file can be tailored to specify what files should be processed by the sass processor:
+
+```xml
+<PropertyGroup>
+   <EnableDefaultSassItems>false</EnableDefaultSassItems>  <!-- take full-control -->
+   <DefaultSassExcludes>node_modules/**;lib/vendor/**</DefaultSassExcludes> <!-- exclude certain directories -->
+</PropertyGroup>
+
+<ItemGroup>
+  <SassFile Include="Styles/*.scss" /> <!-- add files manually -->
+</ItemGroup>
+```
+
 ## Bypass Visual Studio fast up to date check
 
 Visual studio does a quick check to find changed files. However if you edit the sass files, it does not see these as project changes.
@@ -49,7 +64,6 @@ If you edit sass files a lot you can instruct Visual Studio to rely on msbuild, 
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
 </PropertyGroup>
 ```
-
 ## Support
 
 The support is largely dependant on [LibSassHost](https://github.com/Taritsyn/LibSassHost)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ ___
 
 `LibSassBuilder` can be installed on any project, however the underlying build tool requires [.NET 5](https://dotnet.microsoft.com/download/dotnet/5.0) installed on the machine.
 
+## Bypass Visual Studio fast up to date check
+
+Visual studio does a quick check to find changed files. However if you edit the sass files, it does not see these as project changes.
+If you edit sass files a lot you can instruct Visual Studio to rely on msbuild, place the following property in your .csproj.
+
+```xml
+<PropertyGroup>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+</PropertyGroup>
+```
+
 ## Support
 
 The support is largely dependant on [LibSassHost](https://github.com/Taritsyn/LibSassHost)
@@ -47,3 +58,9 @@ This tool contains the following supporting packages:
 - LibSassHost.Native.win-x64
 - LibSassHost.Native.linux-x64
 - LibSassHost.Native.osx-x64
+
+## Package as nuget package
+
+```powershell
+./package.ps1 -PackageDir 'C:/LocalPackages' -Version '1.4.0.1'
+```

--- a/package.ps1
+++ b/package.ps1
@@ -1,0 +1,18 @@
+param (
+    [string] $PackageDir = 'out',
+    
+    [Parameter(Mandatory)]
+    [string] $Version 
+)
+
+$projectFile = "$PSScriptRoot/src/LibSassBuilder/LibSassBuilder.csproj"
+$nuspecProjectFile = "$PSScriptRoot/package/LibSassBuilder.csproj"
+$nuspecFile = "$PSScriptRoot/package/LibSassBuilder.nuspec"
+
+& dotnet build $projectFile -p:Version=$Version -c Release -o "$PSScriptRoot/package/tool"
+& dotnet pack $projectFile -p:Version=$Version -c Release -o $PackageDir
+$xml = [Xml](Get-Content -Path $nuspecFile -Raw)
+$xml.package.metadata.version = $Version
+$xml.Save($nuspecFile)
+& dotnet pack $nuspecProjectFile -p:Version=$Version -c Release -o $PackageDir
+#& dotnet pack --project $projectFile -pVersion=$Version -o $OutputDir

--- a/package/LibSassBuilder.csproj
+++ b/package/LibSassBuilder.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NuspecFile>LibSassBuilder.nuspec</NuspecFile>
+
+    <NoBuild>true</NoBuild>
+    <NoRestore>true</NoRestore>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+</Project>

--- a/package/LibSassBuilder.nuspec
+++ b/package/LibSassBuilder.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>LibSassBuilder</id>
-    <version>1.4.0</version>
+    <version>1.4.0.2</version>
     <title>LibSassBuilder</title>
     <summary>Auto build task to compile .scss/.sass files to .css</summary>
     <authors>Johan van Rensburg</authors>
@@ -11,7 +11,8 @@
     <description>Compile Sass files to css on project build.</description>
     <tags>Sass Build LibSass SassBuilder</tags>
     <projectUrl>https://github.com/johan-v-r/LibSassBuilder</projectUrl>
-    <repository type="git" url="https://github.com/johan-v-r/LibSassBuilder.git"></repository>
+    <repository type="git" url="https://github.com/johan-v-r/LibSassBuilder.git">
+    </repository>
     <license type="expression">MIT</license>
     <icon>sass.png</icon>
   </metadata>

--- a/package/build/LibSassBuilder.props
+++ b/package/build/LibSassBuilder.props
@@ -1,0 +1,22 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- https://natemcmaster.com/blog/2017/11/11/build-tools-in-nuget/ -->
+  <PropertyGroup>
+    <SassExe Condition=" '$(SassExe)'=='' ">$(MSBuildThisFileDirectory)../tool/LibSassBuilder.dll</SassExe>
+    <LibSassBuilderMessageLevel Condition=" '$(LibSassBuilderMessageLevel)'=='' ">High</LibSassBuilderMessageLevel>
+
+    <EnableDefaultSassItems Condition="'$(EnableDefaultSassItems)'==''">true</EnableDefaultSassItems>
+    <DefaultSassExcludes>**/node_modules/**;node_modules/**;**/logs/**;logs/**</DefaultSassExcludes>
+
+    <!--
+    Target used by dotnet-watch to resolve additional items.
+    -->
+    <CustomCollectWatchItems>$(CustomCollectWatchItems);_LibSassBuilderCustomCollectWatchItems</CustomCollectWatchItems>
+  </PropertyGroup>
+  
+  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultSassItems)' == 'true'">
+    <SassFile Include="**/*.scss" ExcludeFromSingleFile="true" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultSassExcludes);$(DefaultExcludesInProjectFolder);" />
+    <SassFile Include="**/*.sass" ExcludeFromSingleFile="true" Exclude="$(DefaultSassExcludes);$(DefaultExcludesInProjectFolder)" />
+    <None Remove="**/*.scss" />
+    <None Remove="**/*.sass" />
+  </ItemGroup>
+</Project>

--- a/package/build/LibSassBuilder.props
+++ b/package/build/LibSassBuilder.props
@@ -6,11 +6,6 @@
 
     <EnableDefaultSassItems Condition="'$(EnableDefaultSassItems)'==''">true</EnableDefaultSassItems>
     <DefaultSassExcludes>**/node_modules/**;node_modules/**;**/logs/**;logs/**</DefaultSassExcludes>
-
-    <!--
-    Target used by dotnet-watch to resolve additional items.
-    -->
-    <CustomCollectWatchItems>$(CustomCollectWatchItems);_LibSassBuilderCustomCollectWatchItems</CustomCollectWatchItems>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultSassItems)' == 'true'">

--- a/package/build/LibSassBuilder.targets
+++ b/package/build/LibSassBuilder.targets
@@ -1,10 +1,63 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- https://natemcmaster.com/blog/2017/11/11/build-tools-in-nuget/ -->
-  <PropertyGroup>
-    <SassExe Condition=" '$(SassExe)'=='' ">$(MSBuildThisFileDirectory)../tool/LibSassBuilder.dll</SassExe>
-  </PropertyGroup>
 
-  <Target Name="SassBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="dotnet &quot;$(SassExe)&quot;" />
+  <PropertyGroup>
+    <_LibSassBuilderHashCacheFile>$(IntermediateOutputPath)$(MSBuildProjectFile).LibSassBuilder.cache</_LibSassBuilderHashCacheFile>
+    <_LibSassBuilderListFile>$(IntermediateOutputPath)$(MSBuildProjectFile).LibSassBuilder.sass-list</_LibSassBuilderListFile>
+  </PropertyGroup>
+  
+  <Target Name="_LibSassBuilderCustomCollectWatchItems">
+    <ItemGroup>
+      <Watch Include="%(SassFile.FullPath)" Condition="'%(SassFile.Watch)' != 'false'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="LibSassBuilderClean"
+          BeforeTargets="BeforeClean">
+    <Delete Files="$(_LibSassBuilderHashCacheFile)" />
+    <Delete Files="$(_LibSassBuilderListFile)" />
+  </Target>
+
+  <Target Name="LibSassBuilderBuild"        
+          BeforeTargets="BeforeBuild"  
+          Condition="'@(SassFile->Count())'!='0'">
+
+    <Message Text="Evaluating Sass files" Importance="$(LibSassBuilderMessageLevel)" />
+
+    <Hash ItemsToHash="@(SassFile->'%(FullPath)-%(ModifiedTime)')">
+      <Output TaskParameter="HashResult" PropertyName="LibSassBuilderDependencyHash" />
+    </Hash>
+
+    <ReadLinesFromFile
+        File="$(_LibSassBuilderHashCacheFile)"
+        Condition="Exists('$(_LibSassBuilderHashCacheFile)')">
+      <Output
+          TaskParameter="Lines"
+          ItemName="OldLibSassBuilderDependencyHash"/>
+    </ReadLinesFromFile>
+
+    <PropertyGroup>
+      <LibSassBuilderDependenciesChanged>false</LibSassBuilderDependenciesChanged>
+      <LibSassBuilderDependenciesChanged Condition=" '$(LibSassBuilderDependencyHash)' != '@(OldLibSassBuilderDependencyHash)' ">true</LibSassBuilderDependenciesChanged>
+    </PropertyGroup>
+    
+    <Message Text="Sass hash New = $(LibSassBuilderDependencyHash)" Importance="$(LibSassBuilderMessageLevel)" />
+    <Message Text="Sass hash Old = @(OldLibSassBuilderDependencyHash)" Importance="$(LibSassBuilderMessageLevel)" />
+    <Message Text="Sass changed  = $(LibSassBuilderDependenciesChanged)" Importance="$(LibSassBuilderMessageLevel)" />
+
+    <Delete Files="$(_LibSassBuilderListFile)"
+            Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' " />
+    <WriteLinesToFile File="$(_LibSassBuilderListFile)" 
+                      Lines="%(SassFile.FullPath)" 
+                      Overwrite="False" 
+                      Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' "/>
+
+    <Exec Command="dotnet &quot;$(SassExe)&quot; &quot;$(_LibSassBuilderListFile)&quot;" 
+          Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' "/>
+
+    <WriteLinesToFile File="$(_LibSassBuilderHashCacheFile)" 
+                      Lines="$(LibSassBuilderDependencyHash)" 
+                      Overwrite="True" 
+                      WriteOnlyWhenDifferent="True"
+                      Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' "/>
   </Target>
 </Project>

--- a/package/build/LibSassBuilder.targets
+++ b/package/build/LibSassBuilder.targets
@@ -2,23 +2,39 @@
 
   <PropertyGroup>
     <_LibSassBuilderHashCacheFile>$(IntermediateOutputPath)$(MSBuildProjectFile).LibSassBuilder.cache</_LibSassBuilderHashCacheFile>
-    <_LibSassBuilderListFile>$(IntermediateOutputPath)$(MSBuildProjectFile).LibSassBuilder.sass-list</_LibSassBuilderListFile>
+    <LibSassShouldBuild>false</LibSassShouldBuild>
   </PropertyGroup>
   
-  <Target Name="_LibSassBuilderCustomCollectWatchItems">
+<!--
+  Target used by dotnet-watch to resolve additional items.
+  Add target to CustomCollectWatchItems
+-->
+  <PropertyGroup>
+    <CustomCollectWatchItems>$(CustomCollectWatchItems);_LibSass_CustomCollectWatchItems</CustomCollectWatchItems>
+  </PropertyGroup>  
+  <Target Name="_LibSass_CustomCollectWatchItems">
     <ItemGroup>
       <Watch Include="%(SassFile.FullPath)" Condition="'%(SassFile.Watch)' != 'false'" />
     </ItemGroup>
   </Target>
 
-  <Target Name="LibSassBuilderClean"
+<!--
+  Target to clean temporary output
+  Deletes the hash file, consider deleting the generated .css files? Scary...
+-->
+  <Target Name="LibSass_Clean"
           BeforeTargets="BeforeClean">
     <Delete Files="$(_LibSassBuilderHashCacheFile)" />
-    <Delete Files="$(_LibSassBuilderListFile)" />
   </Target>
 
-  <Target Name="LibSassBuilderBuild"        
-          BeforeTargets="BeforeBuild"  
+<!--
+  This target calculates the hash of all files (only filename & modification timestamp, so no disk access is needed)
+  Outputs:
+     LibSassShouldBuild = true if hash has changed
+     LibSassBuilderDependencyHash the new hash
+-->
+  <Target Name="LibSass_DetermineBuildNeeded"        
+          BeforeTargets="LibSass_Build"  
           Condition="'@(SassFile->Count())'!='0'">
 
     <Message Text="Evaluating Sass files" Importance="$(LibSassBuilderMessageLevel)" />
@@ -36,28 +52,40 @@
     </ReadLinesFromFile>
 
     <PropertyGroup>
-      <LibSassBuilderDependenciesChanged>false</LibSassBuilderDependenciesChanged>
-      <LibSassBuilderDependenciesChanged Condition=" '$(LibSassBuilderDependencyHash)' != '@(OldLibSassBuilderDependencyHash)' ">true</LibSassBuilderDependenciesChanged>
+      <LibSassShouldBuild Condition=" '$(LibSassBuilderDependencyHash)' != '@(OldLibSassBuilderDependencyHash)' ">true</LibSassShouldBuild>
     </PropertyGroup>
     
     <Message Text="Sass hash New = $(LibSassBuilderDependencyHash)" Importance="$(LibSassBuilderMessageLevel)" />
     <Message Text="Sass hash Old = @(OldLibSassBuilderDependencyHash)" Importance="$(LibSassBuilderMessageLevel)" />
-    <Message Text="Sass changed  = $(LibSassBuilderDependenciesChanged)" Importance="$(LibSassBuilderMessageLevel)" />
+    <Message Text="Sass changed  = $(LibSassShouldBuild)" Importance="$(LibSassBuilderMessageLevel)" />
+  </Target>
+  
+<!-- 
+  Invokes the sass tool
+-->
+  <Target Name="LibSass_Build" 
+          BeforeTargets="BeforeBuild"  
+          Condition="'$(LibSassShouldBuild)' == 'true'">
+    <PropertyGroup>
+      <_SassFileList>@(SassFile->'&quot;%(FullPath)&quot;', ' ')</_SassFileList> <!-- all files, space seperated, surrounded with quotes -->
+    </PropertyGroup>
+    <Message Text="$(_SassFileList)" Importance="High" />
 
-    <Delete Files="$(_LibSassBuilderListFile)"
-            Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' " />
-    <WriteLinesToFile File="$(_LibSassBuilderListFile)" 
-                      Lines="%(SassFile.FullPath)" 
-                      Overwrite="False" 
-                      Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' "/>
+    <Exec Command="dotnet &quot;$(SassExe)&quot; $(_SassFileList)"/>
+  </Target>
 
-    <Exec Command="dotnet &quot;$(SassExe)&quot; &quot;$(_LibSassBuilderListFile)&quot;" 
-          Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' "/>
+<!-- 
+  Save the hash to file if it had changed, do this after the build so it will not skip the next build on failures
+-->
+  <Target Name="LibSass_SaveNewHash"
+          AfterTargets="LibSass_Build"
+          BeforeTargets="BeforeBuild"  
+          Condition=" '$(LibSassShouldBuild)' == 'true' ">
+    <Message Text="Sass hash: saving new..." Importance="$(LibSassBuilderMessageLevel)" />
 
     <WriteLinesToFile File="$(_LibSassBuilderHashCacheFile)" 
                       Lines="$(LibSassBuilderDependencyHash)" 
                       Overwrite="True" 
-                      WriteOnlyWhenDifferent="True"
-                      Condition=" '$(LibSassBuilderDependenciesChanged)' == 'true' "/>
+                      WriteOnlyWhenDifferent="True" />
   </Target>
 </Project>

--- a/src/LibSassBuilder.Tests/test-files/test-indented-format.css
+++ b/src/LibSassBuilder.Tests/test-files/test-indented-format.css
@@ -1,0 +1,1 @@
+body{color:black}

--- a/src/LibSassBuilder.Tests/test-files/test-new-format.css
+++ b/src/LibSassBuilder.Tests/test-files/test-new-format.css
@@ -1,0 +1,1 @@
+body{color:black}


### PR DESCRIPTION
I had the issue when using "dotnet watch run" that it did not detect .scss changes.
I added support and also conditional support for skipping the sass targets if nothing changed.

* Skip sass compile when the hash of filenames and modification dates changed.
* Allows control from within your project files to specify what files to compile
* Added package.ps1 for my convenience (packages .nupkg)
* Added instructions for DisableFastUpToDateCheck

Kind regards,
Jelle