### PR TITLE
Exclude nested folders and underscore files

### DIFF
--- a/package/LibSassBuilder.nuspec
+++ b/package/LibSassBuilder.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>LibSassBuilder</id>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <title>LibSassBuilder</title>
     <summary>Auto build task to compile .scss/.sass files to .css</summary>
     <authors>Johan van Rensburg</authors>

--- a/package/build/LibSassBuilder.props
+++ b/package/build/LibSassBuilder.props
@@ -10,7 +10,7 @@
     <LibSassMessageLevel Condition=" '$(LibSassMessageLevel)'=='' ">Normal</LibSassMessageLevel>
 
     <EnableDefaultSassItems Condition="'$(EnableDefaultSassItems)'==''">true</EnableDefaultSassItems>
-    <DefaultSassExcludes>**/node_modules/**;node_modules/**;**/logs/**;logs/**</DefaultSassExcludes>
+    <DefaultSassExcludes>**/bin/**;**/obj/**;**/node_modules/**;**/logs/**</DefaultSassExcludes>
 
     <!-- Provide LibSassBuilderArgs to take complete control -->
     <LibSassBuilderArgs Condition=" '$(LibSassBuilderArgs)'=='' "></LibSassBuilderArgs>
@@ -20,8 +20,8 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultSassItems)' == 'true'">
-    <SassFile Include="**/*.scss" ExcludeFromSingleFile="true" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultSassExcludes);$(DefaultExcludesInProjectFolder);" />
-    <SassFile Include="**/*.sass" ExcludeFromSingleFile="true" Exclude="$(DefaultSassExcludes);$(DefaultExcludesInProjectFolder)" />
+    <SassFile Include="**/*.scss" ExcludeFromSingleFile="true" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultSassExcludes);$(DefaultExcludesInProjectFolder);**/_*" />
+    <SassFile Include="**/*.sass" ExcludeFromSingleFile="true" Exclude="$(DefaultSassExcludes);$(DefaultExcludesInProjectFolder);**/_*" />
     <None Remove="**/*.scss" />
     <None Remove="**/*.sass" />
   </ItemGroup>

--- a/src/LibSassBuilder/LibSassBuilder.csproj
+++ b/src/LibSassBuilder/LibSassBuilder.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<Version>1.6.0</Version>
+		<Version>1.6.1</Version>
 		<TargetFramework>net5.0</TargetFramework>
 		<PackAsTool>true</PackAsTool>
 		<PackageId>LibSassBuilder-Tool</PackageId>

--- a/src/LibSassBuilder/Program.cs
+++ b/src/LibSassBuilder/Program.cs
@@ -82,7 +82,10 @@ namespace LibSassBuilder
 			{
 				var fileInfo = new FileInfo(file);
 				if (fileInfo.Name.StartsWith("_"))
+				{
+					WriteVerbose($"Skipping: {fileInfo.FullName}");
 					continue;
+				}
 
 				WriteVerbose($"Processing: {fileInfo.FullName}");
 


### PR DESCRIPTION
@JelleHissink I had to exclude nested `bin` & `obj` folders as well as files starting with underscores by default.

Ran into issues when dealing with downloaded `libman` projects. Some of them contain `bin/obj` folders, and lots of `_*.scss` files which just made the argument list from MSBuild too big.

Excluding the nested folders brings it more in-line with the CLI by default.
Excluding the underscore files are really just to help MSBuild.

You see any problems with this?