### PR TITLE
New option that specifies the include path

### DIFF
--- a/src/LibSassBuilder.IncludeTests/IncludeTests.cs
+++ b/src/LibSassBuilder.IncludeTests/IncludeTests.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using Xunit;
+
+namespace LibSassBuilder.IncludeTests
+{
+	// This project is configured to run LibSassBuilder in LibSassBuilder.Tests.csproj
+	public class IncludeTests
+	{
+		private readonly string _fileDirectory;
+
+		public IncludeTests()
+		{
+			_fileDirectory = Path.Join(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.FullName, "test-files");
+		}
+
+		[Theory]
+		[InlineData("wwwroot", "someStyle.css")]
+		public void FilesTest(string subFolder, string cssFileName)
+		{
+			var cssFilePath = Path.Join(_fileDirectory, subFolder, cssFileName);
+
+			Assert.True(File.Exists(cssFilePath));
+
+			File.Delete(cssFilePath);
+		}
+
+		[Theory]
+		[InlineData("vars", "_variables.css")]
+		public void ExcludedFilesTest(string subFolder, string cssFileName)
+		{
+			var cssFilePath = Path.Join(_fileDirectory, subFolder, cssFileName);
+
+			Assert.False(File.Exists(cssFilePath));
+		}
+	}
+}

--- a/src/LibSassBuilder.IncludeTests/LibSassBuilder.IncludeTests.csproj
+++ b/src/LibSassBuilder.IncludeTests/LibSassBuilder.IncludeTests.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LibSassBuilder\LibSassBuilder.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <SassIncludePath Include="$(MSBuildProjectDirectory)/test-files/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <SassIncludePaths Include="@(SassIncludePath->'%(RootDir)%(Directory)'->Distinct())"></SassIncludePaths>
+  </ItemGroup>
+
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <PropertyGroup Condition="'@(SassIncludePaths)' != ''">
+      <_SassIncludePathList>--include @(SassIncludePaths->'&quot;%(FullPath)&quot;', ' ')</_SassIncludePathList>
+    </PropertyGroup>
+    <Exec Command="dotnet run --project ../LibSassBuilder $(_SassIncludePathList)" />
+  </Target>
+
+</Project>

--- a/src/LibSassBuilder.IncludeTests/test-files/vars/_variables.scss
+++ b/src/LibSassBuilder.IncludeTests/test-files/vars/_variables.scss
@@ -1,0 +1,1 @@
+﻿$good-size: 14px;

--- a/src/LibSassBuilder.IncludeTests/test-files/wwwroot/someStyle.scss
+++ b/src/LibSassBuilder.IncludeTests/test-files/wwwroot/someStyle.scss
@@ -1,0 +1,5 @@
+@import 'vars/variables';
+
+body {
+    font-size: $good-size;
+}

--- a/src/LibSassBuilder.sln
+++ b/src/LibSassBuilder.sln
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibSassBuilder.IncludeTests", "LibSassBuilder.IncludeTests\LibSassBuilder.IncludeTests.csproj", "{F2E4F357-5510-4262-8E0B-12800AD6073D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{16069D4E-516D-4DE6-A0E7-D2429E1F7485}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16069D4E-516D-4DE6-A0E7-D2429E1F7485}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16069D4E-516D-4DE6-A0E7-D2429E1F7485}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2E4F357-5510-4262-8E0B-12800AD6073D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2E4F357-5510-4262-8E0B-12800AD6073D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2E4F357-5510-4262-8E0B-12800AD6073D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2E4F357-5510-4262-8E0B-12800AD6073D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/LibSassBuilder/GenericOptions.cs
+++ b/src/LibSassBuilder/GenericOptions.cs
@@ -30,6 +30,19 @@ namespace LibSassBuilder
                 SassCompilationOptions.OutputStyle = value;
             }
         }
+
+        [Option('i', "include", Required = false, HelpText = "Specify the include paths.")]
+        public IEnumerable<string> IncludeDirectories
+        {
+            get
+            {
+                return SassCompilationOptions.IncludePaths;
+            }
+            set
+            {
+                SassCompilationOptions.IncludePaths = value?.ToList();
+            }
+        }
     }
 
     public enum OutputLevel

--- a/src/LibSassBuilder/Program.cs
+++ b/src/LibSassBuilder/Program.cs
@@ -79,6 +79,16 @@ namespace LibSassBuilder
 
 		async Task CompileFilesAsync(IEnumerable<string> sassFiles)
 		{
+            if (Options.OutputLevel >= OutputLevel.Verbose &&
+				Options.SassCompilationOptions.IncludePaths is not null &&
+                Options.SassCompilationOptions.IncludePaths.Count != 0)
+            {
+				WriteVerbose($"Include paths:");
+
+				foreach(var path in Options.SassCompilationOptions.IncludePaths)
+					WriteVerbose($"\t{path}");
+            }
+
 			foreach (var file in sassFiles)
 			{
 				var fileInfo = new FileInfo(file);


### PR DESCRIPTION
Specifying of the include path can help with imports relative to project root (https://github.com/johan-v-r/LibSassBuilder/issues/14)