### PR TITLE
Revert to using dotnet, but include x86 .dll for libsass

### DIFF
--- a/package/build/LibSassBuilder.props
+++ b/package/build/LibSassBuilder.props
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\DesignTime\LibSassBuilder.DesignTime.targets" Condition="'$(DesignTimeBuild)' == 'true'" />
 
   <PropertyGroup>
-    <SassExe Condition=" '$(SassExe)'=='' ">$(MSBuildThisFileDirectory)../tool/LibSassBuilder</SassExe>
+    <SassExe Condition=" '$(SassExe)'=='' ">$(MSBuildThisFileDirectory)../tool/LibSassBuilder.dll</SassExe>
     <!-- outputstyle option for lsb (compressed, condensed, nested, expanded) --> 
     <LibSassOutputStyle Condition=" '$(LibSassOutputStyle)'=='' ">compressed</LibSassOutputStyle> 
     <!-- level option for lsb -->

--- a/package/build/LibSassBuilder.targets
+++ b/package/build/LibSassBuilder.targets
@@ -92,7 +92,7 @@
           Condition="'$(LibSassBuilderArgs)' != ''  ">
     <Message Text="Invoking sass preprocessor..." Importance="$(LibSassMessageLevel)" />
 
-    <Exec Command="&quot;$(SassExe)&quot; $(LibSassBuilderArgs) "/>
+    <Exec Command="dotnet &quot;$(SassExe)&quot; $(LibSassBuilderArgs) "/>
   </Target>
 
 <!-- 

--- a/src/LibSassBuilder/LibSassBuilder.csproj
+++ b/src/LibSassBuilder/LibSassBuilder.csproj
@@ -23,6 +23,7 @@
 		<PackageReference Include="LibSassHost.Native.linux-x64" Version="1.3.2" />
 		<PackageReference Include="LibSassHost.Native.osx-x64" Version="1.3.2" />
 		<PackageReference Include="LibSassHost.Native.win-x64" Version="1.3.2" />
+		<PackageReference Include="LibSassHost.Native.win-x86" Version="1.3.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This should revert the #41 and solve issue #59 as well as provide an alternative for the x86 dotnet.exe issue on windows as reported in #39 